### PR TITLE
Update cnesreport version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,50 @@ This plugin is free software; you can redistribute it and/or modify it under the
 - Run an analysis
 - Architecture
 
+### Compatibility matrix
+<table>
+ <tr>
+  <td><b>Sonar CNES Scan Plugin / CNES Report</b></td>
+  <td><b>1.1.0</b></td>
+  <td><b>1.2.0</b></td>
+  <td><b>1.2.1</b></td>
+  <td><b>2.0.0</b></td>
+  <td><b>2.1.0</b></td>
+ </tr>
+ <tr>
+  <td><b>1.0.0</b></td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>-</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td><b>1.1.0</b></td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>-</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td><b>1.2.0</b></td>
+  <td>x</td>
+  <td>x</td>
+  <td>x</td>
+  <td>-</td>
+  <td>-</td>
+ </tr>
+ <tr>
+  <td><b>1.3.0</b></td>
+  <td>-</td>
+  <td>-</td>
+  <td>-</td>
+  <td>x</td>
+  <td>x</td>
+ </tr>
+</table>
+
 ### How to contribute
 If you experienced a problem with the plugin please open an issue. Inside this issue please explain us how to reproduce this issue and paste the log.
 

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -63,7 +63,7 @@ cnes.page.help.key=cnesscan/help
 cnes.page.help.name=CNES Help
 
 # Command to export the report
-cnes.command.report=java -jar %s --sonar.url %s --sonar.project.id \"%s\" --report.author \"%s\" --report.date \"%s\" --report.path \"%s\" --report.template \"%s\" --issues.template \"%s\" --report.locale \"fr_FR\"
+cnes.command.report=java -jar %s --server %s --project \"%s\" --author \"%s\" --date \"%s\" --output \"%s\" --template-report \"%s\" --template-spreadsheet \"%s\" --language \"fr_FR\"
 # Command pattern to run an scan
 cnes.command.scan=%s/bin/sonar-scanner -X -D project.settings=%s/%s/sonar-project.properties -D sonar.projectBaseDir=%s/%s &> .cat-sonar-scanner.log
 # Separator of different quality profiles in a request
@@ -197,7 +197,7 @@ property.definition.report.path.key=sonar.report.path
 property.definition.report.path.name=Reports extension file
 property.definition.report.path.api.key=report_path
 property.definition.report.path.desc=Sonar CNES Report extension executable. (.jar)
-property.definition.report.path.default=/opt/sonar/extensions/cnes/sonar-report-cnes.jar
+property.definition.report.path.default=/opt/sonar/extensions/cnes/cnesreport.jar
 
 # Definition of value for the SonarQube's timeout property definition
 property.definition.pylintrc.key=sonar.pylintrc.path


### PR DESCRIPTION
In order to correct issues in Docker CAT, we need to use the last version of CNES Report.
Consequently, this plugin has to evolve in order to call the CNES Report tool the right way, before we can integrate it in a new version of Docker CAT.