### PR TITLE
Fix no longer available link to docker-cat user guide

### DIFF
--- a/src/main/resources/static/templates/help.html
+++ b/src/main/resources/static/templates/help.html
@@ -28,7 +28,7 @@
                     <li>- <strong>The README file:</strong> <a href="https://github.com/lequal/sonar-cnes-scan-plugin">README.md</a></li>
                     <li>- <strong>The README file of sonar-cnes-report:</strong> <a href="https://github.com/lequal/sonar-cnes-report">README.md</a></li>
                     <br/>
-                    <li>- <strong>The user-guide of docker-CAT:</strong> <a href="https://lequal.github.io/CAT/how-to-use-cat">User-guide</a></li>
+                    <li>- <strong>The user-guide of docker-CAT:</strong> <a href="https://lequal.github.io/tools/how-to-use-cat">User-guide</a></li>
                     <li>- <strong>The presentation of the tools from lequal:</strong> <a href="https://lequal.github.io/">lequal.github.io</a></li>
                 </ul>
                 <p>If you find a bug, feel free to open an issue at <a href="https://github.com/lequal/sonar-cnes-scan-plugin/issues">github.com/lequal/sonar-cnes-scan-plugin/issues</a></p>


### PR DESCRIPTION
# Fix broken link

## Problem

The link to CAT user guide is broken, namely [https://lequal.github.io/CAT/how-to-use-cat](https://lequal.github.io/CAT/how-to-use-cat).

## Solution

Update the link to [https://lequal.github.io/tools/how-to-use-cat](https://lequal.github.io/tools/how-to-use-cat).